### PR TITLE
Adjust the MultiplayerReturnToSize variable when manually scaling

### DIFF
--- a/PracticeModManager.cs
+++ b/PracticeModManager.cs
@@ -428,7 +428,9 @@ namespace SuperliminalPracticeMod
 			if (GameManager.GM.player != null && newScale > 0.0001f)
 			{
 				playerMotor.transform.localScale = new Vector3(newScale, newScale, newScale);
-				GameManager.GM.player.GetComponent<PlayerResizer>().Poke();
+				PlayerResizer playerResizer = GameManager.GM.player.GetComponent<PlayerResizer>();
+				playerResizer.MultiplayerReturnToSize = newScale;
+				playerResizer.Poke();
 			}
 		}
 


### PR DESCRIPTION
In multiplayer matches, using the hotkeys to change the player scale feels jittery and unreliable, and in some situations the game will prevent the player's scale from changing beyond a certain point (especially after getting grabbed or walking through a portal). I believe the reason for this is the `MultiplayerReturnToSize` variable which the game will use to decide what scale to gradually scale the player back to.

This pull request updates that variable whenever we manually set the player's scale. This means that using any of the three hotkeys in a multiplayer match should reliably set the player's scale to the desired scale, and the player won't gradually be returned to any other scale.