### PR TITLE
Print global position rather than local position

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -7,7 +7,7 @@ using MelonLoader;
 using UnityEngine;
 using Harmony;
 
-[assembly: MelonInfo(typeof(SuperliminalPracticeMod.Main), "Superliminal Practice Mod", "0.4.1", "Micrologist#2351")]
+[assembly: MelonInfo(typeof(SuperliminalPracticeMod.Main), "Superliminal Practice Mod", "0.4.2", "Micrologist#2351")]
 [assembly: MelonGame("PillowCastle", "Superliminal")]
 [assembly: MelonGame("PillowCastle", "SuperliminalSteam")]
 [assembly: MelonGame("PillowCastle", "SuperliminalGOG")]

--- a/PracticeModManager.cs
+++ b/PracticeModManager.cs
@@ -20,6 +20,7 @@ namespace SuperliminalPracticeMod
 		public Text grabbedObjectText;
 		public PauseMenu pauseMenu;
 		public MouseLook mouseLook;
+		public CharacterController characterController;
 
 		Vector3 storedPosition;
 		Quaternion storedCapsuleRotation;
@@ -99,6 +100,7 @@ namespace SuperliminalPracticeMod
 			{
 				player = GameManager.GM.player;
 				playerMotor = player.GetComponent<CharacterMotor>();
+				characterController = playerMotor.GetComponent<CharacterController>();
 				playerCamera = player.GetComponentInChildren<Camera>();
 				mouseLook = playerCamera.GetComponent<MouseLook>();
 				resizeScript = playerCamera.GetComponent<ResizeScript>();

--- a/PracticeModManager.cs
+++ b/PracticeModManager.cs
@@ -299,7 +299,7 @@ namespace SuperliminalPracticeMod
 		string GetPlayerTextString()
 		{
 			Vector3 position = playerMotor.transform.position;
-			Vector3 velocity = playerMotor.GetComponent<CharacterController>().velocity;
+			Vector3 velocity = characterController.velocity;
 			Vector3 rotation = playerMotor.transform.rotation.eulerAngles;
 			float scale = playerMotor.transform.localScale.x;
 			string dynamicInfo = "";

--- a/PracticeModManager.cs
+++ b/PracticeModManager.cs
@@ -296,9 +296,9 @@ namespace SuperliminalPracticeMod
 
 		string GetPlayerTextString()
 		{
-			Vector3 position = playerMotor.transform.localPosition;
+			Vector3 position = playerMotor.transform.position;
 			Vector3 velocity = playerMotor.GetComponent<CharacterController>().velocity;
-			Vector3 rotation = playerMotor.transform.localRotation.eulerAngles;
+			Vector3 rotation = playerMotor.transform.rotation.eulerAngles;
 			float scale = playerMotor.transform.localScale.x;
 			string dynamicInfo = "";
 


### PR DESCRIPTION
This fixes a discrepancy with the "teleport" command in some levels, as well as a few oddities I found while developing the hide and seek mod. In Dollhouse, Labyrinth, and Whitespace, the player's local position is offset from the global position for whatever reason. So by attempting to teleport to a set of coordinates in those levels, you would appear somewhere unexpected.

This practice mod uses the global position for the teleport console command and storing/loading the player's transformation, so I figure it makes sense to print the same coordinates here. Though I don't have experience with Unity, so I'm not aware of a reason that local position would be used instead - feel free to advise.